### PR TITLE
[AM-199] feat: 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/amondfarm/api/member/controller/MemberController.java
+++ b/src/main/java/com/amondfarm/api/member/controller/MemberController.java
@@ -2,21 +2,21 @@ package com.amondfarm.api.member.controller;
 
 import javax.validation.Valid;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.amondfarm.api.member.domain.Member;
 import com.amondfarm.api.member.dto.ExperienceRequest;
 import com.amondfarm.api.member.dto.ExperienceResponse;
-import com.amondfarm.api.member.dto.SigninRequest;
-import com.amondfarm.api.member.dto.SigninResponse;
+import com.amondfarm.api.member.dto.SignUpRequest;
+import com.amondfarm.api.member.dto.SignUpResponse;
+import com.amondfarm.api.member.dto.WithdrawRequest;
+import com.amondfarm.api.member.dto.WithdrawResponse;
 import com.amondfarm.api.member.enums.ProviderType;
 import com.amondfarm.api.member.service.MemberService;
 
@@ -36,9 +36,15 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	@PostMapping("/v1/signin")
-	public ResponseEntity<SigninResponse> join(@RequestBody @Valid SigninRequest request) {
-		SigninResponse response = memberService.join(request);
+	@PostMapping("/v1/signup")
+	public ResponseEntity<SignUpResponse> join(@RequestBody @Valid SignUpRequest request) {
+		SignUpResponse response = memberService.join(request);
+		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/v1/withdraw")
+	public ResponseEntity<WithdrawResponse> withdraw(@RequestBody @Valid WithdrawRequest request) {
+		WithdrawResponse response = memberService.withdraw(request);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/amondfarm/api/member/domain/Member.java
+++ b/src/main/java/com/amondfarm/api/member/domain/Member.java
@@ -12,6 +12,7 @@ import org.hibernate.annotations.ColumnDefault;
 
 import com.amondfarm.api.common.domain.BaseTimeEntity;
 import com.amondfarm.api.member.enums.Gender;
+import com.amondfarm.api.member.enums.MemberStatus;
 import com.amondfarm.api.member.enums.ProviderType;
 
 import lombok.AccessLevel;
@@ -50,6 +51,10 @@ public class Member extends BaseTimeEntity {
 	private String nickname;
 
 	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MemberStatus status;
+
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = true, length = 1)
 	private Gender gender;
 
@@ -61,20 +66,26 @@ public class Member extends BaseTimeEntity {
 	private int exp;
 
 	@Builder
-	public Member(Long id, ProviderType provider, String uid, String email, String nickname, Gender gender,
-		int ageGroup,
-		int exp) {
+	public Member(Long id, ProviderType provider, String uid, String email, String nickname, MemberStatus status,
+		Gender gender, int ageGroup, int exp) {
 		this.id = id;
 		this.provider = provider;
 		this.uid = uid;
 		this.email = email;
 		this.nickname = nickname;
+		this.status = status;
 		this.gender = gender;
 		this.ageGroup = ageGroup;
 		this.exp = exp;
 	}
 
+
+
 	public void changeExp(int exp) {
 		this.exp = exp;
+	}
+
+	public void changeStatus(MemberStatus status) {
+		this.status = status;
 	}
 }

--- a/src/main/java/com/amondfarm/api/member/dto/SignUpRequest.java
+++ b/src/main/java/com/amondfarm/api/member/dto/SignUpRequest.java
@@ -2,9 +2,9 @@ package com.amondfarm.api.member.dto;
 
 import com.amondfarm.api.member.domain.Member;
 import com.amondfarm.api.member.enums.Gender;
+import com.amondfarm.api.member.enums.MemberStatus;
 import com.amondfarm.api.member.enums.ProviderType;
 
-import lombok.Builder;
 import lombok.Data;
 
 /**
@@ -16,7 +16,7 @@ import lombok.Data;
 
 
 @Data
-public class SigninRequest {
+public class SignUpRequest {
 
 	private ProviderType provider;
 	private String uid;
@@ -25,23 +25,13 @@ public class SigninRequest {
 	private Gender gender;
 	private int ageGroup;
 
-	@Builder
-	public SigninRequest(ProviderType provider, String uid, String email, String nickname, Gender gender, int ageGroup) {
-		this.provider = provider;
-		this.uid = uid;
-		this.email = email;
-		this.nickname = nickname;
-		this.gender = gender;
-		this.ageGroup = ageGroup;
-	}
-
-
 	public Member toEntity() {
 		return Member.builder()
 			.provider(provider)
 			.uid(uid)
 			.email(email)
 			.nickname(nickname)
+			.status(MemberStatus.ACTIVE)
 			.gender(gender)
 			.ageGroup(ageGroup)
 			.build();

--- a/src/main/java/com/amondfarm/api/member/dto/SignUpResponse.java
+++ b/src/main/java/com/amondfarm/api/member/dto/SignUpResponse.java
@@ -12,7 +12,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class SigninResponse {
+public class SignUpResponse {
 
 	private String message;
 }

--- a/src/main/java/com/amondfarm/api/member/dto/WithdrawRequest.java
+++ b/src/main/java/com/amondfarm/api/member/dto/WithdrawRequest.java
@@ -1,0 +1,20 @@
+package com.amondfarm.api.member.dto;
+
+import com.amondfarm.api.member.domain.Member;
+import com.amondfarm.api.member.enums.ProviderType;
+
+import lombok.Data;
+
+/**
+ * WithdrawRequest DTO
+ *
+ * @since 2022-09-01
+ * @author jwlee
+ */
+
+@Data
+public class WithdrawRequest {
+
+	private ProviderType provider;
+	private String uid;
+}

--- a/src/main/java/com/amondfarm/api/member/dto/WithdrawResponse.java
+++ b/src/main/java/com/amondfarm/api/member/dto/WithdrawResponse.java
@@ -1,0 +1,17 @@
+package com.amondfarm.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * WithdrawResponse DTO
+ *
+ * @since 2022-09-01
+ * @author jwlee
+ */
+
+@Data
+@AllArgsConstructor
+public class WithdrawResponse {
+	private String message;
+}

--- a/src/main/java/com/amondfarm/api/member/enums/MemberStatus.java
+++ b/src/main/java/com/amondfarm/api/member/enums/MemberStatus.java
@@ -1,0 +1,14 @@
+package com.amondfarm.api.member.enums;
+
+/**
+ * MemberStatus Enum
+ *
+ * @since 2022-09-01
+ * @author jwlee
+ */
+
+public enum MemberStatus {
+	ACTIVE,
+	WITHDRAWAL,
+	DORMANT
+}

--- a/src/main/java/com/amondfarm/api/member/service/MemberService.java
+++ b/src/main/java/com/amondfarm/api/member/service/MemberService.java
@@ -1,16 +1,16 @@
 package com.amondfarm.api.member.service;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.amondfarm.api.member.domain.Member;
 import com.amondfarm.api.member.dto.ExperienceRequest;
 import com.amondfarm.api.member.dto.ExperienceResponse;
-import com.amondfarm.api.member.dto.SigninRequest;
-import com.amondfarm.api.member.dto.SigninResponse;
+import com.amondfarm.api.member.dto.SignUpRequest;
+import com.amondfarm.api.member.dto.SignUpResponse;
+import com.amondfarm.api.member.dto.WithdrawRequest;
+import com.amondfarm.api.member.dto.WithdrawResponse;
+import com.amondfarm.api.member.enums.MemberStatus;
 import com.amondfarm.api.member.enums.ProviderType;
 import com.amondfarm.api.member.repository.MemberRepository;
 
@@ -31,11 +31,20 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 
 	@Transactional
-	public SigninResponse join(SigninRequest request) {
+	public SignUpResponse join(SignUpRequest request) {
 		Member member = request.toEntity();
 		validateDuplicateMember(member);	// 중복회원 체크
 		memberRepository.save(member);
-		return new SigninResponse("ok");
+		return new SignUpResponse("ok");
+	}
+
+	@Transactional
+	public WithdrawResponse withdraw(WithdrawRequest request) {
+		Member member = memberRepository.findByProviderAndUid(request.getProvider(), request.getUid())
+			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
+
+		member.changeStatus(MemberStatus.WITHDRAWAL);
+		return new WithdrawResponse("ok");
 	}
 
 	public ExperienceResponse getExperience(ProviderType provider, String uid) {


### PR DESCRIPTION
Resolve #11 

회원탈퇴 API 생성 완료하였습니다.
실제로 회원을 삭제하지 않고 회원상태 정보만 탈퇴회원으로 변경하였고,
추가로 회원가입 API path 를 SignIn 에서 Signup 으로 변경하였습니다.