### PR TITLE
[AM-199] 중복검사 및 경험치 조회변경 대상을 Active 상태의 회원으로 수정

### DIFF
--- a/src/main/java/com/amondfarm/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/amondfarm/api/member/repository/MemberRepository.java
@@ -4,8 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.amondfarm.api.member.domain.Member;
+import com.amondfarm.api.member.enums.MemberStatus;
 import com.amondfarm.api.member.enums.ProviderType;
 
 /**
@@ -18,4 +21,7 @@ import com.amondfarm.api.member.enums.ProviderType;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByProviderAndUid(ProviderType provider, String uid);
+
+	@Query("select m from Member m where m.provider = :provider and m.uid = :uid and m.status = :status")
+	Optional<Member> findMember(@Param("provider") ProviderType provider, @Param("uid") String uid, @Param("status") MemberStatus status);
 }

--- a/src/main/java/com/amondfarm/api/member/service/MemberService.java
+++ b/src/main/java/com/amondfarm/api/member/service/MemberService.java
@@ -40,7 +40,7 @@ public class MemberService {
 
 	@Transactional
 	public WithdrawResponse withdraw(WithdrawRequest request) {
-		Member member = memberRepository.findByProviderAndUid(request.getProvider(), request.getUid())
+		Member member = memberRepository.findMember(request.getProvider(), request.getUid(), MemberStatus.ACTIVE)
 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
 
 		member.changeStatus(MemberStatus.WITHDRAWAL);
@@ -49,7 +49,7 @@ public class MemberService {
 
 	public ExperienceResponse getExperience(ProviderType provider, String uid) {
 
-		Member member = memberRepository.findByProviderAndUid(provider, uid)
+		Member member = memberRepository.findMember(provider, uid, MemberStatus.ACTIVE)
 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
 
 		return new ExperienceResponse(member.getExp());
@@ -58,7 +58,7 @@ public class MemberService {
 	@Transactional
 	public ExperienceResponse updateExperience(ExperienceRequest request) {
 
-		Member member = memberRepository.findByProviderAndUid(request.getProvider(), request.getUid())
+		Member member = memberRepository.findMember(request.getProvider(), request.getUid(), MemberStatus.ACTIVE)
 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
 
 		member.changeExp(request.getExp());
@@ -67,9 +67,9 @@ public class MemberService {
 
 	private void validateDuplicateMember(Member member) {
 
-		memberRepository.findByProviderAndUid(member.getProvider(), member.getUid())
+		memberRepository.findMember(member.getProvider(), member.getUid(), MemberStatus.ACTIVE)
 			.ifPresent(m -> {
-				throw new IllegalArgumentException("이미 존재하는 회원입니다. 회원 Mail : " + m.getEmail());
+				throw new IllegalArgumentException("이미 존재하는 회원입니다.");
 			});
 	}
 }


### PR DESCRIPTION
Resolve #14 

- 중복처리를 ACTIVE 회원 중에서만 중복처리
- EXP 반환 또는 수정을 ACTIVE 회원 중에서만 처리