### PR TITLE
[AM-229] 미션 목록 및 성공 여부 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
    	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
     implementation 'com.google.code.gson:gson'
+
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/amondfarm/api/config/ApplicationStartupValue.java
+++ b/src/main/java/com/amondfarm/api/config/ApplicationStartupValue.java
@@ -1,0 +1,21 @@
+package com.amondfarm.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+
+@Component
+@Getter
+public class ApplicationStartupValue implements ApplicationListener<ApplicationStartedEvent> {
+
+	@Value("${app.version}")
+	private String version;
+
+	@Override
+	public void onApplicationEvent(ApplicationStartedEvent event) {
+
+	}
+}

--- a/src/main/java/com/amondfarm/api/controller/MemberController.java
+++ b/src/main/java/com/amondfarm/api/controller/MemberController.java
@@ -11,13 +11,18 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.amondfarm.api.config.ApplicationStartupValue;
+import com.amondfarm.api.dto.CharacterNicknameRequest;
+import com.amondfarm.api.dto.CharacterNicknameResponse;
 import com.amondfarm.api.dto.ExperienceRequest;
 import com.amondfarm.api.dto.ExperienceResponse;
+import com.amondfarm.api.dto.MessageResponse;
 import com.amondfarm.api.dto.MissionCompleteResponse;
 import com.amondfarm.api.dto.MissionRequest;
 import com.amondfarm.api.dto.MissionResponse;
 import com.amondfarm.api.dto.SignUpRequest;
 import com.amondfarm.api.dto.SignUpResponse;
+import com.amondfarm.api.dto.VersionResponse;
 import com.amondfarm.api.dto.WithdrawRequest;
 import com.amondfarm.api.dto.WithdrawResponse;
 import com.amondfarm.api.domain.enums.ProviderType;
@@ -38,6 +43,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
 	private final MemberService memberService;
+	private final ApplicationStartupValue startupValue;
 
 	@PostMapping("/v1/signup")
 	public ResponseEntity<SignUpResponse> join(@RequestBody @Valid SignUpRequest request) {
@@ -80,5 +86,24 @@ public class MemberController {
 	public ResponseEntity<MissionCompleteResponse> updateMission(@RequestBody MissionRequest request) {
 		MissionCompleteResponse response = memberService.completeMission(request);
 		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/v1/nickname")
+	public ResponseEntity<CharacterNicknameResponse> getCharacterNickname(
+		@RequestParam(value = "provider") ProviderType providerType,
+		@RequestParam(value = "uid") String uid) {
+
+		return ResponseEntity.ok(memberService.getCharacterNickname(providerType, uid));
+	}
+
+	@PostMapping("/v1/nickname")
+	public ResponseEntity<MessageResponse> setCharacterNickname(@RequestBody CharacterNicknameRequest request) {
+		memberService.setCharacterNickname(request);
+		return ResponseEntity.ok(new MessageResponse("success"));
+	}
+
+	@GetMapping("/v1/version")
+	public ResponseEntity<VersionResponse> getVersion() {
+		return ResponseEntity.ok(new VersionResponse(startupValue.getVersion()));
 	}
 }

--- a/src/main/java/com/amondfarm/api/controller/MemberController.java
+++ b/src/main/java/com/amondfarm/api/controller/MemberController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.amondfarm.api.dto.ExperienceRequest;
 import com.amondfarm.api.dto.ExperienceResponse;
+import com.amondfarm.api.dto.MissionCompleteResponse;
 import com.amondfarm.api.dto.MissionRequest;
 import com.amondfarm.api.dto.MissionResponse;
 import com.amondfarm.api.dto.SignUpRequest;
@@ -75,9 +76,9 @@ public class MemberController {
 		return ResponseEntity.ok(response);
 	}
 
-	// @PutMapping("/v1/mission")
-	// public ResponseEntity<MissionResponse> updateMission(@RequestBody MissionRequest request) {
-	// 	MissionResponse response = memberService.updateMission(request);
-	// 	return ResponseEntity.ok(response);
-	// }
+	@PutMapping("/v1/mission")
+	public ResponseEntity<MissionCompleteResponse> updateMission(@RequestBody MissionRequest request) {
+		MissionCompleteResponse response = memberService.completeMission(request);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/amondfarm/api/controller/MemberController.java
+++ b/src/main/java/com/amondfarm/api/controller/MemberController.java
@@ -1,83 +1,83 @@
-// package com.amondfarm.api.controller;
-//
-// import javax.validation.Valid;
-//
-// import org.springframework.http.ResponseEntity;
-// import org.springframework.web.bind.annotation.DeleteMapping;
-// import org.springframework.web.bind.annotation.GetMapping;
-// import org.springframework.web.bind.annotation.PostMapping;
-// import org.springframework.web.bind.annotation.PutMapping;
-// import org.springframework.web.bind.annotation.RequestBody;
-// import org.springframework.web.bind.annotation.RequestParam;
-// import org.springframework.web.bind.annotation.RestController;
-//
-// import com.amondfarm.api.dto.ExperienceRequest;
-// import com.amondfarm.api.dto.ExperienceResponse;
-// import com.amondfarm.api.dto.MissionRequest;
-// import com.amondfarm.api.dto.MissionResponse;
-// import com.amondfarm.api.dto.SignUpRequest;
-// import com.amondfarm.api.dto.SignUpResponse;
-// import com.amondfarm.api.dto.WithdrawRequest;
-// import com.amondfarm.api.dto.WithdrawResponse;
-// import com.amondfarm.api.domain.enums.ProviderType;
-// import com.amondfarm.api.service.MemberService;
-//
-// import lombok.RequiredArgsConstructor;
-//
-// /**
-//  * Member Controller
-//  *
-//  * @since 2022-08-29
-//  * @author jwlee
-//  */
-//
-//
-// @RestController
-// @RequiredArgsConstructor
-// public class MemberController {
-//
-// 	private final MemberService memberService;
-//
-// 	@PostMapping("/v1/signup")
-// 	public ResponseEntity<SignUpResponse> join(@RequestBody @Valid SignUpRequest request) {
-// 		SignUpResponse response = memberService.join(request);
-// 		return ResponseEntity.ok(response);
-// 	}
-//
-// 	@DeleteMapping("/v1/withdraw")
-// 	public ResponseEntity<WithdrawResponse> withdraw(@RequestBody @Valid WithdrawRequest request) {
-// 		WithdrawResponse response = memberService.withdraw(request);
-// 		return ResponseEntity.ok(response);
-// 	}
-//
-// 	@GetMapping("/v1/exp")
-// 	public ResponseEntity<ExperienceResponse> getExperience(
-// 		@RequestParam(value = "providerType") ProviderType providerType,
-// 		@RequestParam(value = "uid") String uid) {
-//
-// 		ExperienceResponse response = memberService.getExperience(providerType, uid);
-// 		return ResponseEntity.ok(response);
-// 	}
-//
-// 	@PutMapping("/v1/exp")
-// 	public ResponseEntity<ExperienceResponse> updateExperience(@RequestBody ExperienceRequest request) {
-// 		ExperienceResponse response = memberService.updateExperience(request);
-// 		return ResponseEntity.ok(response);
-// 	}
-//
-// 	@GetMapping("/v1/mission")
-// 	public ResponseEntity<MissionResponse> getMission(
-// 		@RequestParam(value = "providerType") ProviderType providerType,
-// 		@RequestParam(value = "uid") String uid) {
-//
-// 		MissionResponse response = memberService.getMission(providerType, uid);
-//
-// 		return ResponseEntity.ok(response);
-// 	}
-//
-// 	@PutMapping("/v1/mission")
-// 	public ResponseEntity<MissionResponse> updateMission(@RequestBody MissionRequest request) {
-// 		MissionResponse response = memberService.updateMission(request);
-// 		return ResponseEntity.ok(response);
-// 	}
-// }
+package com.amondfarm.api.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.amondfarm.api.dto.ExperienceRequest;
+import com.amondfarm.api.dto.ExperienceResponse;
+import com.amondfarm.api.dto.MissionRequest;
+import com.amondfarm.api.dto.MissionResponse;
+import com.amondfarm.api.dto.SignUpRequest;
+import com.amondfarm.api.dto.SignUpResponse;
+import com.amondfarm.api.dto.WithdrawRequest;
+import com.amondfarm.api.dto.WithdrawResponse;
+import com.amondfarm.api.domain.enums.ProviderType;
+import com.amondfarm.api.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Member Controller
+ *
+ * @since 2022-08-29
+ * @author jwlee
+ */
+
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@PostMapping("/v1/signup")
+	public ResponseEntity<SignUpResponse> join(@RequestBody @Valid SignUpRequest request) {
+		SignUpResponse response = memberService.join(request);
+		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/v1/withdraw")
+	public ResponseEntity<WithdrawResponse> withdraw(@RequestBody @Valid WithdrawRequest request) {
+		WithdrawResponse response = memberService.withdraw(request);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/v1/exp")
+	public ResponseEntity<ExperienceResponse> getExperience(
+		@RequestParam(value = "provider") ProviderType providerType,
+		@RequestParam(value = "uid") String uid) {
+
+		ExperienceResponse response = memberService.getExperience(providerType, uid);
+		return ResponseEntity.ok(response);
+	}
+
+	@PutMapping("/v1/exp")
+	public ResponseEntity<ExperienceResponse> updateExperience(@RequestBody ExperienceRequest request) {
+		ExperienceResponse response = memberService.updateExperience(request);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/v1/mission")
+	public ResponseEntity<MissionResponse> getMission(
+		@RequestParam(value = "provider") ProviderType providerType,
+		@RequestParam(value = "uid") String uid) {
+
+		MissionResponse response = memberService.getMemberMission(providerType, uid);
+
+		return ResponseEntity.ok(response);
+	}
+
+	// @PutMapping("/v1/mission")
+	// public ResponseEntity<MissionResponse> updateMission(@RequestBody MissionRequest request) {
+	// 	MissionResponse response = memberService.updateMission(request);
+	// 	return ResponseEntity.ok(response);
+	// }
+}

--- a/src/main/java/com/amondfarm/api/domain/Member.java
+++ b/src/main/java/com/amondfarm/api/domain/Member.java
@@ -1,106 +1,107 @@
-// package com.amondfarm.api.domain;
-//
-// import java.util.ArrayList;
-// import java.util.List;
-//
-// import javax.persistence.CascadeType;
-// import javax.persistence.Column;
-// import javax.persistence.Entity;
-// import javax.persistence.EnumType;
-// import javax.persistence.Enumerated;
-// import javax.persistence.GeneratedValue;
-// import javax.persistence.GenerationType;
-// import javax.persistence.Id;
-// import javax.persistence.OneToMany;
-//
-// import org.hibernate.annotations.ColumnDefault;
-//
-// import com.amondfarm.api.common.domain.BaseTimeEntity;
-// import com.amondfarm.api.domain.enums.Gender;
-// import com.amondfarm.api.domain.enums.MemberStatus;
-// import com.amondfarm.api.domain.enums.ProviderType;
-//
-// import lombok.AccessLevel;
-// import lombok.Builder;
-// import lombok.Getter;
-// import lombok.NoArgsConstructor;
-//
-// /**
-//  * Member Model
-//  *
-//  * @since 2022-08-05
-//  * @author jwlee
-//  */
-//
-// @Entity
-// @Getter
-// @NoArgsConstructor(access = AccessLevel.PROTECTED)
-// public class Member extends BaseTimeEntity {
-//
-// 	@Id
-// 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-// 	@Column(name = "member_id")
-// 	private Long id;
-//
-// 	@Enumerated(EnumType.STRING)
-// 	@Column(nullable = false)
-// 	private ProviderType provider;
-//
-// 	@Column(nullable = false)
-// 	private String uid;
-//
-// 	@Column(nullable = true)
-// 	private String email;
-//
-// 	@Column(nullable = false)
-// 	private String nickname;
-//
-// 	@Enumerated(EnumType.STRING)
-// 	@Column(nullable = false)
-// 	private MemberStatus status;
-//
-// 	@Enumerated(EnumType.STRING)
-// 	@Column(nullable = true, length = 1)
-// 	private Gender gender;
-//
-// 	@Column(nullable = true)
-// 	private int ageGroup;
-//
-// 	@Column(nullable = false)
-// 	@ColumnDefault("0")
-// 	private int mission;
-//
-// 	@Column(nullable = false)
-// 	@ColumnDefault("0")
-// 	private int exp;
-//
-// 	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-// 	private List<UserMission> userMissions = new ArrayList<>();
-//
-// 	@Builder
-// 	public Member(Long id, ProviderType provider, String uid, String email, String nickname, MemberStatus status,
-// 		Gender gender, int ageGroup, int mission, int exp) {
-// 		this.id = id;
-// 		this.provider = provider;
-// 		this.uid = uid;
-// 		this.email = email;
-// 		this.nickname = nickname;
-// 		this.status = status;
-// 		this.gender = gender;
-// 		this.ageGroup = ageGroup;
-// 		this.mission = mission;
-// 		this.exp = exp;
-// 	}
-//
-// 	public void changeExp(int exp) {
-// 		this.exp = exp;
-// 	}
-//
-// 	public void changeStatus(MemberStatus status) {
-// 		this.status = status;
-// 	}
-//
-// 	public void changeMission(int mission) {
-// 		this.mission = mission;
-// 	}
-// }
+package com.amondfarm.api.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import com.amondfarm.api.common.domain.BaseTimeEntity;
+import com.amondfarm.api.domain.enums.Gender;
+import com.amondfarm.api.domain.enums.MemberStatus;
+import com.amondfarm.api.domain.enums.ProviderType;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Member Model
+ *
+ * @since 2022-08-05
+ * @author jwlee
+ */
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ProviderType provider;
+
+	@Column(nullable = false)
+	private String uid;
+
+	@Column(nullable = true)
+	private String email;
+
+	@Column(nullable = false)
+	private String nickname;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MemberStatus status;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = true, length = 1)
+	private Gender gender;
+
+	@Column(nullable = true)
+	private int ageGroup;
+
+	@Column(nullable = false)
+	@ColumnDefault("0")
+	private int exp;
+
+	private String characterName;
+
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+	private List<MemberMission> memberMissions = new ArrayList<>();
+
+	@Builder
+	public Member(Long id, ProviderType provider, String uid, String email, String nickname, MemberStatus status,
+		Gender gender, int ageGroup, int exp) {
+		this.id = id;
+		this.provider = provider;
+		this.uid = uid;
+		this.email = email;
+		this.nickname = nickname;
+		this.status = status;
+		this.gender = gender;
+		this.ageGroup = ageGroup;
+		this.exp = exp;
+	}
+
+	public void changeExp(int exp) {
+		this.exp = exp;
+	}
+
+	public void changeCharacterName(String characterName) {
+		this.characterName = characterName;
+	}
+
+	public void changeStatus(MemberStatus status) {
+		this.status = status;
+	}
+
+	public void addMemberMission(MemberMission memberMission) {
+		memberMissions.add(memberMission);
+	}
+}

--- a/src/main/java/com/amondfarm/api/domain/MemberMission.java
+++ b/src/main/java/com/amondfarm/api/domain/MemberMission.java
@@ -47,4 +47,8 @@ public class MemberMission {
 		this.mission = mission;
 		this.missionStatus = MissionStatus.INCOMPLETE;
 	}
+
+	public void completeMission() {
+		this.missionStatus = MissionStatus.COMPLETE;
+	}
 }

--- a/src/main/java/com/amondfarm/api/domain/MemberMission.java
+++ b/src/main/java/com/amondfarm/api/domain/MemberMission.java
@@ -1,56 +1,50 @@
-// package com.amondfarm.api.domain;
-//
-// import javax.persistence.Column;
-// import javax.persistence.Entity;
-// import javax.persistence.EnumType;
-// import javax.persistence.Enumerated;
-// import javax.persistence.FetchType;
-// import javax.persistence.GeneratedValue;
-// import javax.persistence.GenerationType;
-// import javax.persistence.Id;
-// import javax.persistence.JoinColumn;
-// import javax.persistence.ManyToOne;
-//
-// import com.amondfarm.api.domain.enums.MissionStatus;
-//
-// import lombok.AccessLevel;
-// import lombok.AllArgsConstructor;
-// import lombok.Getter;
-// import lombok.NoArgsConstructor;
-//
-// @Entity
-// @Getter
-// @NoArgsConstructor(access = AccessLevel.PROTECTED)
-// @AllArgsConstructor(access = AccessLevel.PRIVATE)
-// public class MemberMission {
-//
-// 	@Id
-// 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-// 	@Column(name = "member_mission_id")
-// 	private Long id;
-//
-// 	@ManyToOne(fetch = FetchType.LAZY)
-// 	@JoinColumn(name = "member_id")
-// 	private Member member;
-//
-// 	@ManyToOne(fetch = FetchType.LAZY)
-// 	@JoinColumn(name = "mission_id")
-// 	private Mission mission;
-//
-// 	@Enumerated(EnumType.STRING)
-// 	@Column(name = "mission_status", nullable = false)
-// 	private MissionStatus missionStatus;
-//
-// 	//==생성 메소드==//
-// 	public static MemberMission createMemberMission(Member member, Mission mission) {
-// 		MemberMission memberMission = new MemberMission(null, member, mission, MissionStatus.YET);
-// 		if (member != null) {
-// 			member.addMemberMission(memberMission);
-// 		}
-// 		if (mission != null) {
-// 			mission.addMemberMission(memberMission);
-// 		}
-//
-// 		return userMission;
-// 	}
-// }
+package com.amondfarm.api.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.amondfarm.api.domain.enums.MissionStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberMission {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_mission_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "mission_id")
+	private Mission mission;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "mission_status", nullable = false)
+	private MissionStatus missionStatus;
+
+	public MemberMission(Member member, Mission mission) {
+		this.member = member;
+		this.mission = mission;
+		this.missionStatus = MissionStatus.INCOMPLETE;
+	}
+}

--- a/src/main/java/com/amondfarm/api/domain/Mission.java
+++ b/src/main/java/com/amondfarm/api/domain/Mission.java
@@ -25,26 +25,15 @@ public class Mission {
 	@Column(name = "mission_id")
 	private Long id;
 
-	@Column(name = "mission_name", nullable = false)
-	private String name;
+	@Column(name = "mission_title")
+	private String title;
+
+	@Column(name = "mission_content", nullable = false)
+	private String content;
 
 	@Column(name = "mission_exp", nullable = false)
 	private int exp;
 
-	@Column(name = "mission_image", nullable = false)
-	private String image;
-
-	// @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL)
-	// private List<UserMission> userMissions = new ArrayList<>();
-
-	@OneToMany(mappedBy = "mission", cascade = CascadeType.ALL)
-	private List<MemberMission> memberMissions = new ArrayList<>();
-
-	// public void addUserMission(UserMission userMission) {
-	// 	userMissions.add(userMission);
-	// }
-
-	public void addMemberMission(MemberMission memberMission) {
-		memberMissions.add(memberMission);
-	}
+	@Column(name = "mission_image_url", nullable = false)
+	private String imageUrl;
 }

--- a/src/main/java/com/amondfarm/api/domain/User.java
+++ b/src/main/java/com/amondfarm/api/domain/User.java
@@ -58,8 +58,8 @@ public class User {
 	@Enumerated(EnumType.STRING)
 	private RoleType roleType;
 
-	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-	private List<UserMission> userMissions = new ArrayList<>();
+	// @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+	// private List<UserMission> userMissions = new ArrayList<>();
 
 	@Builder
 	public User(Long id, String loginId, ProviderType providerType, UserStatus userStatus, String email,
@@ -80,9 +80,9 @@ public class User {
 		return userStatus.equals(UserStatus.ACTIVE);
 	}
 
-	public void addUserMission(UserMission userMission) {
-		userMissions.add(userMission);
-	}
+	// public void addUserMission(UserMission userMission) {
+	// 	userMissions.add(userMission);
+	// }
 
 	public void changeStatus(UserStatus userStatus) {
 		this.userStatus = userStatus;

--- a/src/main/java/com/amondfarm/api/domain/UserMission.java
+++ b/src/main/java/com/amondfarm/api/domain/UserMission.java
@@ -1,59 +1,59 @@
-package com.amondfarm.api.domain;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-
-import org.hibernate.annotations.ColumnDefault;
-
-import com.amondfarm.api.domain.enums.MissionStatus;
-
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Entity
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserMission {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "user_mission_id")
-	private Long id;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id")
-	private User user;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "mission_id")
-	private Mission mission;
-
-	@Enumerated(EnumType.STRING)
-	@Column(name = "mission_status", nullable = false)
-	private MissionStatus missionStatus;
-
-	// //==생성 메소드==//
-	// public static UserMission createUserMission(User user, Mission mission) {
-	// 	UserMission userMission = new UserMission(null, user, mission, MissionStatus.YET);
-	// 	if (user != null) {
-	// 		user.addUserMission(userMission);
-	// 	}
-	// 	if (mission != null) {
-	// 		mission.addUserMission(userMission);
-	// 	}
-	//
-	// 	return userMission;
-	// }
-}
+// package com.amondfarm.api.domain;
+//
+// import javax.persistence.Column;
+// import javax.persistence.Entity;
+// import javax.persistence.EnumType;
+// import javax.persistence.Enumerated;
+// import javax.persistence.FetchType;
+// import javax.persistence.GeneratedValue;
+// import javax.persistence.GenerationType;
+// import javax.persistence.Id;
+// import javax.persistence.JoinColumn;
+// import javax.persistence.ManyToOne;
+//
+// import org.hibernate.annotations.ColumnDefault;
+//
+// import com.amondfarm.api.domain.enums.MissionStatus;
+//
+// import lombok.AccessLevel;
+// import lombok.AllArgsConstructor;
+// import lombok.Builder;
+// import lombok.Getter;
+// import lombok.NoArgsConstructor;
+//
+// @Entity
+// @Getter
+// @NoArgsConstructor(access = AccessLevel.PROTECTED)
+// @AllArgsConstructor(access = AccessLevel.PRIVATE)
+// public class UserMission {
+//
+// 	@Id
+// 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+// 	@Column(name = "user_mission_id")
+// 	private Long id;
+//
+// 	@ManyToOne(fetch = FetchType.LAZY)
+// 	@JoinColumn(name = "user_id")
+// 	private User user;
+//
+// 	@ManyToOne(fetch = FetchType.LAZY)
+// 	@JoinColumn(name = "mission_id")
+// 	private Mission mission;
+//
+// 	@Enumerated(EnumType.STRING)
+// 	@Column(name = "mission_status", nullable = false)
+// 	private MissionStatus missionStatus;
+//
+// 	// //==생성 메소드==//
+// 	// public static UserMission createUserMission(User user, Mission mission) {
+// 	// 	UserMission userMission = new UserMission(null, user, mission, MissionStatus.YET);
+// 	// 	if (user != null) {
+// 	// 		user.addUserMission(userMission);
+// 	// 	}
+// 	// 	if (mission != null) {
+// 	// 		mission.addUserMission(userMission);
+// 	// 	}
+// 	//
+// 	// 	return userMission;
+// 	// }
+// }

--- a/src/main/java/com/amondfarm/api/domain/enums/MemberStatus.java
+++ b/src/main/java/com/amondfarm/api/domain/enums/MemberStatus.java
@@ -1,8 +1,8 @@
-// package com.amondfarm.api.domain.enums;
-//
-//
-// public enum MemberStatus {
-// 	ACTIVE,
-// 	WITHDRAWAL,
-// 	DORMANT
-// }
+package com.amondfarm.api.domain.enums;
+
+
+public enum MemberStatus {
+	ACTIVE,
+	WITHDRAWAL,
+	DORMANT
+}

--- a/src/main/java/com/amondfarm/api/domain/enums/MissionStatus.java
+++ b/src/main/java/com/amondfarm/api/domain/enums/MissionStatus.java
@@ -1,5 +1,5 @@
 package com.amondfarm.api.domain.enums;
 
 public enum MissionStatus {
-	COMPLETE, YET
+	INCOMPLETE, WAIT, COMPLETE
 }

--- a/src/main/java/com/amondfarm/api/domain/enums/ProviderType.java
+++ b/src/main/java/com/amondfarm/api/domain/enums/ProviderType.java
@@ -1,12 +1,5 @@
 package com.amondfarm.api.domain.enums;
 
-/**
- * Provider Type Enum
- *
- * @since 2022-08-29
- * @author jwlee
- */
-
 public enum ProviderType {
 	KAKAO, APPLE
 }

--- a/src/main/java/com/amondfarm/api/dto/CharacterNicknameRequest.java
+++ b/src/main/java/com/amondfarm/api/dto/CharacterNicknameRequest.java
@@ -1,0 +1,14 @@
+package com.amondfarm.api.dto;
+
+import com.amondfarm.api.domain.enums.ProviderType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CharacterNicknameRequest {
+	private ProviderType provider;
+	private String uid;
+	private String nickname;
+}

--- a/src/main/java/com/amondfarm/api/dto/CharacterNicknameResponse.java
+++ b/src/main/java/com/amondfarm/api/dto/CharacterNicknameResponse.java
@@ -1,0 +1,10 @@
+package com.amondfarm.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CharacterNicknameResponse {
+	private String nickname;
+}

--- a/src/main/java/com/amondfarm/api/dto/ExperienceRequest.java
+++ b/src/main/java/com/amondfarm/api/dto/ExperienceRequest.java
@@ -9,7 +9,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class ExperienceRequest {
 
-	private ProviderType providerType;
+	private ProviderType provider;
 	private String uid;
 	private int exp;
 }

--- a/src/main/java/com/amondfarm/api/dto/MessageResponse.java
+++ b/src/main/java/com/amondfarm/api/dto/MessageResponse.java
@@ -1,0 +1,11 @@
+package com.amondfarm.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MessageResponse {
+
+	private String message;
+}

--- a/src/main/java/com/amondfarm/api/dto/MissionCompleteResponse.java
+++ b/src/main/java/com/amondfarm/api/dto/MissionCompleteResponse.java
@@ -1,0 +1,10 @@
+package com.amondfarm.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MissionCompleteResponse {
+	private final String message;
+}

--- a/src/main/java/com/amondfarm/api/dto/MissionInfoDto.java
+++ b/src/main/java/com/amondfarm/api/dto/MissionInfoDto.java
@@ -1,0 +1,39 @@
+package com.amondfarm.api.dto;
+
+import com.amondfarm.api.domain.MemberMission;
+import com.amondfarm.api.domain.enums.MissionStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MissionInfoDto {
+	private Long id;
+	private String imageUrl;
+	private String title;
+	private String content;
+	private int reward;
+	private MissionStatus state;
+
+	@Builder
+	public MissionInfoDto(Long id, String imageUrl, String title, String content, int reward, MissionStatus state) {
+		this.id = id;
+		this.imageUrl = imageUrl;
+		this.title = title;
+		this.content = content;
+		this.reward = reward;
+		this.state = state;
+	}
+
+	public static MissionInfoDto from(MemberMission memberMission) {
+		return MissionInfoDto.builder()
+			.id(memberMission.getMission().getId())
+			.imageUrl(memberMission.getMission().getImageUrl())
+			.title(memberMission.getMission().getTitle())
+			.content(memberMission.getMission().getContent())
+			.reward(memberMission.getMission().getExp())
+			.state(memberMission.getMissionStatus())
+			.build();
+	}
+}

--- a/src/main/java/com/amondfarm/api/dto/MissionRequest.java
+++ b/src/main/java/com/amondfarm/api/dto/MissionRequest.java
@@ -9,7 +9,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class MissionRequest {
 
-	private ProviderType providerType;
+	private ProviderType provider;
 	private String uid;
-	private int mission;
+	private Long missionId;
 }

--- a/src/main/java/com/amondfarm/api/dto/MissionResponse.java
+++ b/src/main/java/com/amondfarm/api/dto/MissionResponse.java
@@ -1,7 +1,10 @@
 package com.amondfarm.api.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * MissionResponse DTO
@@ -10,8 +13,12 @@ import lombok.Data;
  * @author jwlee
  */
 
-@Data
-@AllArgsConstructor
+@Getter
+@NoArgsConstructor
 public class MissionResponse {
-	private int mission;
+	private List<MissionInfoDto> missions = new ArrayList<>();
+
+	public void addInfo(MissionInfoDto dto) {
+		this.missions.add(dto);
+	}
 }

--- a/src/main/java/com/amondfarm/api/dto/VersionResponse.java
+++ b/src/main/java/com/amondfarm/api/dto/VersionResponse.java
@@ -1,0 +1,13 @@
+package com.amondfarm.api.dto;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class VersionResponse {
+	private String version;
+}

--- a/src/main/java/com/amondfarm/api/dto/WithdrawRequest.java
+++ b/src/main/java/com/amondfarm/api/dto/WithdrawRequest.java
@@ -14,6 +14,6 @@ import lombok.Data;
 @Data
 public class WithdrawRequest {
 
-	private ProviderType providerType;
+	private ProviderType provider;
 	private String uid;
 }

--- a/src/main/java/com/amondfarm/api/repository/MemberMissionRepository.java
+++ b/src/main/java/com/amondfarm/api/repository/MemberMissionRepository.java
@@ -1,0 +1,19 @@
+package com.amondfarm.api.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.amondfarm.api.domain.Member;
+import com.amondfarm.api.domain.MemberMission;
+import com.amondfarm.api.domain.Mission;
+
+public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
+	@Query("select mm from MemberMission mm "
+		+ "join fetch mm.member m "
+		+ "join fetch mm.mission ms "
+		+ "where m.id = :id")
+	List<MemberMission> findAllWithMemberAndMission(@Param("id") Long id);
+}

--- a/src/main/java/com/amondfarm/api/repository/MemberMissionRepository.java
+++ b/src/main/java/com/amondfarm/api/repository/MemberMissionRepository.java
@@ -1,19 +1,27 @@
 package com.amondfarm.api.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.amondfarm.api.domain.Member;
 import com.amondfarm.api.domain.MemberMission;
-import com.amondfarm.api.domain.Mission;
 
 public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
+
+	// Member ID 를 이용해서 MemberMission 리스트 조회
 	@Query("select mm from MemberMission mm "
 		+ "join fetch mm.member m "
 		+ "join fetch mm.mission ms "
 		+ "where m.id = :id")
-	List<MemberMission> findAllWithMemberAndMission(@Param("id") Long id);
+	List<MemberMission> findMemberMissionByMemberId(@Param("id") Long id);
+
+	@Query("select mm from MemberMission mm "
+			+ "join fetch mm.member m "
+			+ "join fetch mm.mission ms "
+			+ "where m.id = :member_id and ms.id = :mission_id")
+	Optional<MemberMission> findMemberMissionByMissionId(
+		@Param("member_id") Long memberId, @Param("mission_id") Long missionId);
 }

--- a/src/main/java/com/amondfarm/api/repository/MemberRepository.java
+++ b/src/main/java/com/amondfarm/api/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.amondfarm.api.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.amondfarm.api.domain.Member;
+import com.amondfarm.api.domain.MemberMission;
+import com.amondfarm.api.domain.Mission;
 import com.amondfarm.api.domain.enums.MemberStatus;
 import com.amondfarm.api.domain.enums.UserStatus;
 import com.amondfarm.api.domain.enums.ProviderType;

--- a/src/main/java/com/amondfarm/api/repository/MissionRespository.java
+++ b/src/main/java/com/amondfarm/api/repository/MissionRespository.java
@@ -1,0 +1,10 @@
+package com.amondfarm.api.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.amondfarm.api.domain.Mission;
+
+public interface MissionRespository extends JpaRepository<Mission, Long> {
+}

--- a/src/main/java/com/amondfarm/api/security/config/SecurityConfig.java
+++ b/src/main/java/com/amondfarm/api/security/config/SecurityConfig.java
@@ -69,11 +69,11 @@ public class SecurityConfig
 
 			.and()
 			.authorizeRequests()    //HttpServletRequest를 사용하는 요청들에 대한 접근제한을 설정하겠다
-			.antMatchers("/api/v1/login").permitAll()    // /api/login 에 대한 요청은 인증없이 접근을 허용하겠다
+			.antMatchers("**").permitAll()    // /api/login 에 대한 요청은 인증없이 접근을 허용하겠다
 			// .antMatchers("/api/authenticate").permitAll()	// 로그인
 			// .antMatchers("/api/signup").permitAll()	// 회원가입
 
-			.anyRequest().authenticated()    //나머지 요청들은 전부 인증을 받아야한다.
+			.anyRequest().permitAll()    //나머지 요청들은 전부 인증을 받아야한다.
 
 			.and()
 			.apply(new JwtSecurityConfig(tokenProvider));

--- a/src/main/java/com/amondfarm/api/security/jwt/TokenProvider.java
+++ b/src/main/java/com/amondfarm/api/security/jwt/TokenProvider.java
@@ -40,7 +40,7 @@ public class TokenProvider implements InitializingBean {
 
 	public TokenProvider(
 		@Value("${jwt.secret}") String secret,
-		@Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds) {
+		@Value("${jwt.token-validity-in-milliseconds}") long tokenValidityInSeconds) {
 
 		this.secret = secret;
 		this.tokenValidityInSeconds = tokenValidityInSeconds * 1000;

--- a/src/main/java/com/amondfarm/api/service/MemberService.java
+++ b/src/main/java/com/amondfarm/api/service/MemberService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,8 +12,11 @@ import com.amondfarm.api.domain.Member;
 import com.amondfarm.api.domain.MemberMission;
 import com.amondfarm.api.domain.Mission;
 import com.amondfarm.api.domain.enums.MemberStatus;
+import com.amondfarm.api.dto.CharacterNicknameRequest;
+import com.amondfarm.api.dto.CharacterNicknameResponse;
 import com.amondfarm.api.dto.ExperienceRequest;
 import com.amondfarm.api.dto.ExperienceResponse;
+import com.amondfarm.api.dto.MessageResponse;
 import com.amondfarm.api.dto.MissionCompleteResponse;
 import com.amondfarm.api.dto.MissionInfoDto;
 import com.amondfarm.api.dto.MissionRequest;
@@ -122,5 +126,20 @@ public class MemberService {
 			.ifPresent(m -> {
 				throw new IllegalArgumentException("이미 존재하는 회원입니다.");
 			});
+	}
+
+	public CharacterNicknameResponse getCharacterNickname(ProviderType providerType, String uid) {
+		Member member = memberRepository.findMember(providerType, uid, MemberStatus.ACTIVE)
+			.orElseThrow(() -> new NoSuchElementException("해당 회원이 없습니다."));
+
+		return new CharacterNicknameResponse(member.getCharacterName());
+	}
+
+	@Transactional
+	public void setCharacterNickname(CharacterNicknameRequest request) {
+		Member member = memberRepository.findMember(request.getProvider(), request.getUid(), MemberStatus.ACTIVE)
+			.orElseThrow(() -> new NoSuchElementException("해당 회원이 없습니다."));
+
+		member.changeCharacterName(request.getNickname());
 	}
 }

--- a/src/main/java/com/amondfarm/api/service/MemberService.java
+++ b/src/main/java/com/amondfarm/api/service/MemberService.java
@@ -1,95 +1,119 @@
-// package com.amondfarm.api.service;
-//
-// import org.springframework.stereotype.Service;
-// import org.springframework.transaction.annotation.Transactional;
-//
-// import com.amondfarm.api.domain.Member;
-// import com.amondfarm.api.domain.enums.MemberStatus;
-// import com.amondfarm.api.dto.ExperienceRequest;
-// import com.amondfarm.api.dto.ExperienceResponse;
-// import com.amondfarm.api.dto.MissionRequest;
-// import com.amondfarm.api.dto.MissionResponse;
-// import com.amondfarm.api.dto.SignUpRequest;
-// import com.amondfarm.api.dto.SignUpResponse;
-// import com.amondfarm.api.dto.WithdrawRequest;
-// import com.amondfarm.api.dto.WithdrawResponse;
-// import com.amondfarm.api.domain.enums.ProviderType;
-// import com.amondfarm.api.repository.MemberRepository;
-//
-// import lombok.RequiredArgsConstructor;
-//
-// /**
-//  * Member Service
-//  *
-//  * @since 2022-08-29
-//  * @author jwlee
-//  */
-//
-// @Service
-// @RequiredArgsConstructor
-// @Transactional(readOnly = true)
-// public class MemberService {
-//
-// 	private final MemberRepository memberRepository;
-//
-// 	@Transactional
-// 	public SignUpResponse join(SignUpRequest request) {
-// 		Member member = request.toEntity();
-// 		validateDuplicateMember(member);	// 중복회원 체크
-// 		memberRepository.save(member);
-// 		return new SignUpResponse("ok");
-// 	}
-//
-// 	@Transactional
-// 	public WithdrawResponse withdraw(WithdrawRequest request) {
-// 		Member member = memberRepository.findMember(request.getProviderType(), request.getUid(), MemberStatus.ACTIVE)
-// 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
-//
-// 		member.changeStatus(MemberStatus.WITHDRAWAL);
-// 		return new WithdrawResponse("ok");
-// 	}
-//
-// 	public ExperienceResponse getExperience(ProviderType provider, String uid) {
-//
-// 		Member member = memberRepository.findMember(provider, uid, MemberStatus.ACTIVE)
-// 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
-//
-// 		return new ExperienceResponse(member.getExp());
-// 	}
-//
-// 	@Transactional
-// 	public ExperienceResponse updateExperience(ExperienceRequest request) {
-//
-// 		Member member = memberRepository.findMember(request.getProviderType(), request.getUid(), MemberStatus.ACTIVE)
-// 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
-//
-// 		member.changeExp(request.getExp());
-// 		return new ExperienceResponse(member.getExp());
-// 	}
-//
-// 	@Transactional
-// 	public MissionResponse getMission(ProviderType provider, String uid) {
-//
-// 		Member member = memberRepository.findMember(provider, uid, MemberStatus.ACTIVE)
-// 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
-//
-// 		return new MissionResponse(member.getMission());
-// 	}
-//
-// 	@Transactional
-// 	public MissionResponse updateMission(MissionRequest request) {
-// 		Member member = memberRepository.findMember(request.getProviderType(), request.getUid(), MemberStatus.ACTIVE)
-// 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
-//
-// 		member.changeMission(request.getMission());
-// 		return new MissionResponse(member.getMission());
-// 	}
-//
-// 	private void validateDuplicateMember(Member member) {
-//
-// 		memberRepository.findMember(member.getProvider(), member.getUid(), MemberStatus.ACTIVE)
-// 			.ifPresent(m -> {
-// 				throw new IllegalArgumentException("이미 존재하는 회원입니다.");
-// 			});
-// 	}
-// }
+package com.amondfarm.api.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.amondfarm.api.domain.Member;
+import com.amondfarm.api.domain.MemberMission;
+import com.amondfarm.api.domain.Mission;
+import com.amondfarm.api.domain.enums.MemberStatus;
+import com.amondfarm.api.dto.ExperienceRequest;
+import com.amondfarm.api.dto.ExperienceResponse;
+import com.amondfarm.api.dto.MissionInfoDto;
+import com.amondfarm.api.dto.MissionRequest;
+import com.amondfarm.api.dto.MissionResponse;
+import com.amondfarm.api.dto.SignUpRequest;
+import com.amondfarm.api.dto.SignUpResponse;
+import com.amondfarm.api.dto.WithdrawRequest;
+import com.amondfarm.api.dto.WithdrawResponse;
+import com.amondfarm.api.domain.enums.ProviderType;
+import com.amondfarm.api.repository.MemberMissionRepository;
+import com.amondfarm.api.repository.MemberRepository;
+import com.amondfarm.api.repository.MissionRespository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Member Service
+ *
+ * @since 2022-08-29
+ * @author jwlee
+ */
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	private final MissionRespository missionRespository;
+	private final MemberMissionRepository memberMissionRepository;
+
+	@Transactional
+	public SignUpResponse join(SignUpRequest request) {
+		Member member = request.toEntity();
+		validateDuplicateMember(member);	// 중복회원 체크
+		memberRepository.save(member);
+
+		List<Mission> missions = missionRespository.findAll();
+
+		for (Mission mission : missions) {
+			MemberMission memberMission = new MemberMission(member, mission);
+			member.addMemberMission(memberMission);
+		}
+
+		return new SignUpResponse("ok");
+	}
+
+	@Transactional
+	public WithdrawResponse withdraw(WithdrawRequest request) {
+		Member member = memberRepository.findMember(request.getProvider(), request.getUid(), MemberStatus.ACTIVE)
+			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
+
+		member.changeStatus(MemberStatus.WITHDRAWAL);
+		return new WithdrawResponse("ok");
+	}
+
+	public ExperienceResponse getExperience(ProviderType provider, String uid) {
+
+		Member member = memberRepository.findMember(provider, uid, MemberStatus.ACTIVE)
+			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
+
+		return new ExperienceResponse(member.getExp());
+	}
+
+	@Transactional
+	public ExperienceResponse updateExperience(ExperienceRequest request) {
+
+		Member member = memberRepository.findMember(request.getProvider(), request.getUid(), MemberStatus.ACTIVE)
+			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
+
+		member.changeExp(request.getExp());
+		return new ExperienceResponse(member.getExp());
+	}
+
+	@Transactional
+	public MissionResponse getMemberMission(ProviderType provider, String uid) {
+
+		Member member = memberRepository.findMember(provider, uid, MemberStatus.ACTIVE)
+			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
+
+		List<MemberMission> memberMissions = memberMissionRepository.findAllWithMemberAndMission(member.getId());
+		MissionResponse missionResponse = new MissionResponse();
+
+		for (MemberMission memberMission : memberMissions) {
+			missionResponse.addInfo(MissionInfoDto.from(memberMission));
+		}
+
+		return missionResponse;
+	}
+
+	// @Transactional
+	// public MissionResponse updateMission(MissionRequest request) {
+	// 	Member member = memberRepository.findMember(request.getProviderType(), request.getUid(), MemberStatus.ACTIVE)
+	// 		.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
+	//
+	// 	member.changeMission(request.getMission());
+	// 	return new MissionResponse(member.getMission());
+	// }
+
+	private void validateDuplicateMember(Member member) {
+
+		memberRepository.findMember(member.getProvider(), member.getUid(), MemberStatus.ACTIVE)
+			.ifPresent(m -> {
+				throw new IllegalArgumentException("이미 존재하는 회원입니다.");
+			});
+	}
+}

--- a/src/main/java/com/amondfarm/api/service/UserService.java
+++ b/src/main/java/com/amondfarm/api/service/UserService.java
@@ -118,7 +118,7 @@ public class UserService {
 
 	@Transactional
 	public WithdrawResponse withdraw(WithdrawRequest request) {
-		User user = userRepository.findMember(request.getProviderType(), request.getUid(), UserStatus.ACTIVE)
+		User user = userRepository.findMember(request.getProvider(), request.getUid(), UserStatus.ACTIVE)
 			.orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
 
 		user.changeStatus(UserStatus.WITHDRAWAL);


### PR DESCRIPTION
#19 완료.

## 구현 기능
사용자에게 주어진 미션과, 미션 각각에 대한 성공 여부를 조회합니다.
추가로, 캐릭터 닉네임을 등록/조회할 수 있고
앱 버전에 대한 조회도 가능합니다.

## 세부 내용
- Mission, MemberMission Entity를 구현합니다
- MemberMissionRepository를 구현합니다
- 각 API에 해당하는 Service를 구현합니다
- ApplicationListener를 상속받은 ApplicationStartupValue를 구현합니다