### PR TITLE
[AM-231] 카카오 회원탈퇴 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'com.nimbusds:nimbus-jose-jwt:9.24.3'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 }
 
 dependencyManagement {

--- a/src/main/java/com/amondfarm/api/config/SwaggerConfig.java
+++ b/src/main/java/com/amondfarm/api/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.amondfarm.api.config;
+
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import lombok.RequiredArgsConstructor;
+
+@OpenAPIDefinition(
+	info = @Info(title = "멋난이 개발서버 API 명세서",
+		description = "멋난이팀의 멋진 친환경 서비스 API 명세서",
+		version = "v1"))
+@RequiredArgsConstructor
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public GroupedOpenApi openApi() {
+		String[] paths = {"/v1/**"};
+
+		return GroupedOpenApi.builder()
+			.group("멋난이 서비스 API v1")
+			.pathsToMatch(paths)
+			.build();
+	}
+}

--- a/src/main/java/com/amondfarm/api/dto/WithdrawRequest.java
+++ b/src/main/java/com/amondfarm/api/dto/WithdrawRequest.java
@@ -14,7 +14,6 @@ import lombok.Data;
 @Data
 public class WithdrawRequest {
 
-	private String accessToken;
 	private ProviderType providerType;
 	private String authorizationCode;
 }

--- a/src/main/java/com/amondfarm/api/service/UserService.java
+++ b/src/main/java/com/amondfarm/api/service/UserService.java
@@ -113,11 +113,10 @@ public class UserService {
 
 		if (request.getProviderType().equals(ProviderType.KAKAO)) {
 			// 카카오에 회원탈퇴 요청
-			// TODO
-
-			// 서비스 DB 에 반영
 			User user = getCurrentUser()
 				.orElseThrow(() -> new NoSuchElementException("해당 회원이 없습니다."));
+			kakaoLoginUtil.revoke(user.getLoginId());
+			// 서비스 DB 에 반영
 			user.changeStatus(UserStatus.WITHDRAWAL);
 
 		} else if (request.getProviderType().equals(ProviderType.APPLE)) {

--- a/src/main/java/com/amondfarm/api/util/KakaoLoginUtil.java
+++ b/src/main/java/com/amondfarm/api/util/KakaoLoginUtil.java
@@ -9,9 +9,11 @@ import com.amondfarm.api.domain.User;
 import com.amondfarm.api.domain.enums.ProviderType;
 import com.amondfarm.api.security.dto.LoginRequest;
 import com.amondfarm.api.security.dto.LoginUserInfoDto;
+import com.amondfarm.api.security.util.SecurityUtil;
 import com.amondfarm.api.util.client.KakaoAuthClient;
 import com.amondfarm.api.util.client.KakaoUserApiClient;
 import com.amondfarm.api.util.dto.KakaoToken;
+import com.amondfarm.api.util.dto.KakaoUnlink;
 import com.amondfarm.api.util.dto.KakaoUserInfo;
 
 import lombok.RequiredArgsConstructor;
@@ -59,20 +61,9 @@ public class KakaoLoginUtil implements OAuthUtil {
 		return kakaoUserApiClient.getUserInfo(token.getTokenType() + " " + token.getAccessToken());
 	}
 
-	// public void logout(String accessToken) {
-	// 	try {
-	// 		HttpURLConnection conn = getHttpURLConnection(accessToken);
-	//
-	// 		if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
-	// 			throw new NoSuchElementException("Provider에게서 정보를 받아올 수 없습니다.");
-	// 		}
-	//
-	// 		String result = getResult(conn.getInputStream());
-	//
-	// 		System.out.println("결과");
-	// 		System.out.println(result);
-	// 	} catch (IOException e) {
-	// 		e.printStackTrace();
-	// 	}
-	// }
+	public void revoke(String targetId) {
+
+		KakaoUnlink kakaoUnlink = new KakaoUnlink(targetId);
+		kakaoUserApiClient.unlinkUser(restapiKey, kakaoUnlink);
+	}
 }

--- a/src/main/java/com/amondfarm/api/util/client/KakaoUserApiClient.java
+++ b/src/main/java/com/amondfarm/api/util/client/KakaoUserApiClient.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 import com.amondfarm.api.config.FeignClientConfig;
+import com.amondfarm.api.util.dto.KakaoUnlink;
 import com.amondfarm.api.util.dto.KakaoUserInfo;
 
 @FeignClient(name = "kakaoClient", url = "https://kapi.kakao.com", configuration = FeignClientConfig.class)
@@ -12,4 +13,7 @@ public interface KakaoUserApiClient {
 
 	@PostMapping("/v2/user/me")
 	KakaoUserInfo getUserInfo(@RequestHeader("Authorization") String accessToken);
+
+	@PostMapping("/v1/user/unlink")
+	void unlinkUser(@RequestHeader("Authorization") String appAdminKey, KakaoUnlink kakaoUnlink);
 }

--- a/src/main/java/com/amondfarm/api/util/dto/KakaoUnlink.java
+++ b/src/main/java/com/amondfarm/api/util/dto/KakaoUnlink.java
@@ -1,0 +1,14 @@
+package com.amondfarm.api.util.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUnlink {
+	private String target_id_type;
+	private String target_id;
+
+	public KakaoUnlink(String target_id) {
+		this.target_id_type = "user_id";
+		this.target_id = target_id;
+	}
+}


### PR DESCRIPTION
## 구현 기능
카카오 로그인한 유저의 회원탈퇴를 구현합니다.

## 세부 내용
- [x] 카카오 API 를 호출해서 탈퇴처리.
- [x] 서비스 DB 에 유저 정보 업데이트.