### PR TITLE
[AM-331] 애플 로그인 시 username 전달받도록 수정

### DIFF
--- a/src/main/java/com/amondfarm/api/domain/User.java
+++ b/src/main/java/com/amondfarm/api/domain/User.java
@@ -51,6 +51,8 @@ public class User extends BaseTimeEntity {
 	@Column(name = "reason_for_withdraw")
 	private String reasonForWithdraw;
 
+	private String accountUsername;
+
 	private String loginUsername;
 
 	private Gender gender;
@@ -102,6 +104,7 @@ public class User extends BaseTimeEntity {
 		User user = User.builder()
 			.providerType(userDto.getProviderType())
 			.loginId(userDto.getLoginId())
+			.accountUsername(userDto.getAccountUsername())
 			.loginUsername(userDto.getLoginUsername())
 			.build();
 
@@ -115,11 +118,12 @@ public class User extends BaseTimeEntity {
 	}
 
 	@Builder
-	public User(ProviderType providerType, String loginId, String loginUsername,
+	public User(ProviderType providerType, String loginId, String accountUsername, String loginUsername,
 		Gender gender, String email) {
 
 		this.providerType = providerType;
 		this.loginId = loginId;
+		this.accountUsername = accountUsername;
 		this.loginUsername = loginUsername;
 		this.gender = gender;
 		this.email = email;

--- a/src/main/java/com/amondfarm/api/dto/CreateUserDto.java
+++ b/src/main/java/com/amondfarm/api/dto/CreateUserDto.java
@@ -13,16 +13,18 @@ import lombok.Getter;
 public class CreateUserDto {
 	private ProviderType providerType;
 	private String loginId;
+	private String accountUsername;
 	private String loginUsername;
 	private String email;
 	private List<UserMission> userMissions;
 	private UserPet userPet;
 
 	@Builder
-	public CreateUserDto(ProviderType providerType, String loginId, String loginUsername, String email,
+	public CreateUserDto(ProviderType providerType, String loginId, String accountUsername, String loginUsername, String email,
 		List<UserMission> userMissions, UserPet userPet) {
 		this.providerType = providerType;
 		this.loginId = loginId;
+		this.accountUsername = accountUsername;
 		this.loginUsername = loginUsername;
 		this.email = email;
 		this.userMissions = userMissions;

--- a/src/main/java/com/amondfarm/api/security/dto/LoginRequest.java
+++ b/src/main/java/com/amondfarm/api/security/dto/LoginRequest.java
@@ -15,4 +15,5 @@ public class LoginRequest {
 	private String accessToken;
 	@NotNull
 	private ProviderType providerType;
+	private String username;
 }

--- a/src/main/java/com/amondfarm/api/service/UserService.java
+++ b/src/main/java/com/amondfarm/api/service/UserService.java
@@ -199,6 +199,7 @@ public class UserService {
 		CreateUserDto userDto = CreateUserDto.builder()
 			.loginId(userInfoResponse.getLoginId())
 			.providerType(userInfoResponse.getProviderType())
+			.accountUsername(userInfoResponse.getNickname())
 			.loginUsername(userInfoResponse.getNickname())
 			.email(userInfoResponse.getEmail())
 			.userMissions(userMissions)

--- a/src/main/java/com/amondfarm/api/util/AppleLoginService.java
+++ b/src/main/java/com/amondfarm/api/util/AppleLoginService.java
@@ -76,7 +76,7 @@ public class AppleLoginService implements OAuthService {
 		// 여기서부터 Identity Token 의 payload 들이 신뢰할 수 있는 값들로 증명 완료.
 		// payload 에서 apple 고유 계정 id 등 중요 요소 획득해서 사용하면 됨.
 
-		return parseUserInfo(userInfo);
+		return parseUserInfo(userInfo, loginRequest.getUsername());
 	}
 
 	// Identity Token 검증
@@ -119,17 +119,16 @@ public class AppleLoginService implements OAuthService {
 		return null;
 	}
 
-	private Optional<UserInfoResponse> parseUserInfo(Claims claims) {
+	private Optional<UserInfoResponse> parseUserInfo(Claims claims, String username) {
 
 		//Gson 라이브러리로 JSON파싱
 		JsonObject userInfoObject = JsonParser.parseString(new Gson().toJson(claims)).getAsJsonObject();
-		// System.out.println("userInfoObject = " + userInfoObject.toString());
 		JsonElement appleAlg = userInfoObject.get("sub");
 		String userId = appleAlg.getAsString();
 
-		//TODO : 애플 닉네임 파싱하기 + Response 데이터에 injection 하기
 		return Optional.of(UserInfoResponse.builder()
 			.loginId(userId)
+			.nickname(username)
 			.providerType(ProviderType.APPLE)
 			.build());
 	}


### PR DESCRIPTION
Resolve #60 

계정의 username 과 유저가 변경하여 사용하는 닉네임을 구분했습니다.
추가로 애플 로그인 시 username 을 전달받지 못해 null 이 뜨던 버그를 수정했습니다.