### PR TITLE
[AM-359] 기존 유저 보상 API 구현 및 공지사항 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ application-local.yml
 application-prod.yml
 data.sql
 data-dev.sql
+data-test.sql
 *.p8
 firebase_service_key.json
 docker-compose.yml

--- a/src/main/java/com/amondfarm/api/controller/BetaUserController.java
+++ b/src/main/java/com/amondfarm/api/controller/BetaUserController.java
@@ -1,0 +1,26 @@
+package com.amondfarm.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.amondfarm.api.dto.response.BetaUserRewardResponse;
+import com.amondfarm.api.service.BetaUserService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/v1/beta")
+public class BetaUserController {
+
+	private final BetaUserService betaUserService;
+
+	@GetMapping("/check")
+	public ResponseEntity<BetaUserRewardResponse> getBetaUserReward() {
+		return ResponseEntity.ok(betaUserService.getBetaUserReward());
+	}
+}

--- a/src/main/java/com/amondfarm/api/controller/UtilController.java
+++ b/src/main/java/com/amondfarm/api/controller/UtilController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.amondfarm.api.dto.response.BannerResponse;
 import com.amondfarm.api.dto.response.CheckResponse;
+import com.amondfarm.api.dto.response.NoticeResponse;
 import com.amondfarm.api.service.UtilService;
 import com.amondfarm.api.util.SlackService;
 
@@ -29,5 +30,10 @@ public class UtilController {
 	@GetMapping("/banners")
 	public ResponseEntity<BannerResponse> getBanners() {
 		return ResponseEntity.ok(utilService.getBanners());
+	}
+
+	@GetMapping("/notice")
+	public ResponseEntity<NoticeResponse> getNotice() {
+		return ResponseEntity.ok(utilService.getNotice());
 	}
 }

--- a/src/main/java/com/amondfarm/api/domain/Notice.java
+++ b/src/main/java/com/amondfarm/api/domain/Notice.java
@@ -1,0 +1,30 @@
+package com.amondfarm.api.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notice_id")
+	private Long id;
+
+	@Column(nullable = false)
+	private boolean required;
+
+	@Column(nullable = false)
+	private boolean apply;
+
+	@Column(nullable = false)
+	private String message;
+}

--- a/src/main/java/com/amondfarm/api/dto/response/BetaUserRewardResponse.java
+++ b/src/main/java/com/amondfarm/api/dto/response/BetaUserRewardResponse.java
@@ -1,0 +1,14 @@
+package com.amondfarm.api.dto.response;
+
+import com.amondfarm.api.domain.enums.mission.RewardType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BetaUserRewardResponse {
+	private Boolean isBetaUser;
+	private RewardType rewardType;
+	private int reward;
+}

--- a/src/main/java/com/amondfarm/api/dto/response/NoticeResponse.java
+++ b/src/main/java/com/amondfarm/api/dto/response/NoticeResponse.java
@@ -1,0 +1,12 @@
+package com.amondfarm.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NoticeResponse {
+	private Boolean isApply;
+	private Boolean isRequired;
+	private String message;
+}

--- a/src/main/java/com/amondfarm/api/repository/NoticeRepository.java
+++ b/src/main/java/com/amondfarm/api/repository/NoticeRepository.java
@@ -1,0 +1,11 @@
+package com.amondfarm.api.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.amondfarm.api.domain.Notice;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+	Optional<Notice> findByApplyTrue();
+}

--- a/src/main/java/com/amondfarm/api/service/BetaUserService.java
+++ b/src/main/java/com/amondfarm/api/service/BetaUserService.java
@@ -53,6 +53,9 @@ public class BetaUserService {
 		reward += userBetaPet.getCurrentExp();
 		reward  = reward / 10 + 1;
 
+		// 현재 유저 잔여 보상에 추가
+		currentUser.addReward(reward);
+
 		// 유저 펫 정보 삭제하고 리턴하기
 		userPetRepository.delete(userBetaPet);
 

--- a/src/main/java/com/amondfarm/api/service/BetaUserService.java
+++ b/src/main/java/com/amondfarm/api/service/BetaUserService.java
@@ -1,0 +1,65 @@
+package com.amondfarm.api.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.amondfarm.api.domain.PetLevelValue;
+import com.amondfarm.api.domain.User;
+import com.amondfarm.api.domain.UserPet;
+import com.amondfarm.api.domain.enums.mission.RewardType;
+import com.amondfarm.api.domain.enums.pet.AcquisitionCondition;
+import com.amondfarm.api.dto.response.BetaUserRewardResponse;
+import com.amondfarm.api.repository.PetLevelRepository;
+import com.amondfarm.api.repository.UserPetRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class BetaUserService {
+
+	private final UserService userService;
+	private final UserPetRepository userPetRepository;
+	private final PetLevelRepository petLevelRepository;
+
+
+	@Transactional
+	public BetaUserRewardResponse getBetaUserReward() {
+
+		User currentUser = userService.getCurrentUser();
+		// 현재 유저에게 BETA 캐릭터가 있는지 판단.
+		Optional<UserPet> userPet = currentUser.getUserPets().stream()
+			.filter(up -> up.getPet().getAcquisitionCondition() == AcquisitionCondition.BETA)
+			.findFirst();
+
+		// BETA 캐릭터가 없다면 false 반환
+		if (userPet.isEmpty()) {
+			return BetaUserRewardResponse.builder()
+				.isBetaUser(false)
+				.build();
+		}
+
+		// 리워드 계산하기
+		UserPet userBetaPet = userPet.get();
+		int reward = 0;
+		for (int i = 1; i < userBetaPet.getCurrentLevel(); i++) {
+			PetLevelValue levelValue = petLevelRepository.findByLevel(i).get();
+			reward += levelValue.getMaxExp();
+		}
+		reward += userBetaPet.getCurrentExp();
+		reward  = reward / 10 + 1;
+
+		// 유저 펫 정보 삭제하고 리턴하기
+		userPetRepository.delete(userBetaPet);
+
+		return BetaUserRewardResponse.builder()
+			.isBetaUser(true)
+			.rewardType(RewardType.FISH)
+			.reward(reward)
+			.build();
+	}
+}

--- a/src/main/java/com/amondfarm/api/service/UtilService.java
+++ b/src/main/java/com/amondfarm/api/service/UtilService.java
@@ -43,8 +43,8 @@ public class UtilService {
 			.orElseThrow(() -> new NoSuchElementException("최신 버전의 앱이 없습니다."));
 
 		boolean isRequired = false;
-		// 지금 클라이언트 버전이 필수 업데이트가 필요 or 새로 나온 버전으로 무조건 업데이트 해야 하는 경우
-		if (currentClientVersion.getIsRequired() == 1 || latestVersion.getIsRequired() == 1) {
+		// 지금 클라이언트 버전이 필수 업데이트 필요 시
+		if (currentClientVersion.getIsRequired() == 1) {
 			isRequired = true;
 		}
 

--- a/src/main/java/com/amondfarm/api/service/UtilService.java
+++ b/src/main/java/com/amondfarm/api/service/UtilService.java
@@ -3,18 +3,22 @@ package com.amondfarm.api.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.amondfarm.api.domain.Banner;
+import com.amondfarm.api.domain.Notice;
 import com.amondfarm.api.domain.Version;
 import com.amondfarm.api.domain.enums.version.VersionStatus;
 import com.amondfarm.api.dto.BannerDto;
 import com.amondfarm.api.dto.response.BannerResponse;
 import com.amondfarm.api.dto.response.CheckResponse;
+import com.amondfarm.api.dto.response.NoticeResponse;
 import com.amondfarm.api.repository.BannerRepository;
+import com.amondfarm.api.repository.NoticeRepository;
 import com.amondfarm.api.repository.VersionRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -28,6 +32,7 @@ public class UtilService {
 
 	private final VersionRepository versionRepository;
 	private final BannerRepository bannerRepository;
+	private final NoticeRepository noticeRepository;
 
 	public CheckResponse checkVersion(String clientVersion) {
 		// 해당 버전의 필수 업데이트 요소 체크, 현재 최신 버전 반환
@@ -67,6 +72,21 @@ public class UtilService {
 		return BannerResponse.builder()
 			.totalBanners(banners.size())
 			.banners(bannerDtos)
+			.build();
+	}
+
+	public NoticeResponse getNotice() {
+		Optional<Notice> notice = noticeRepository.findByApplyTrue();
+		if (notice.isEmpty()) {
+			return NoticeResponse.builder()
+				.isApply(false)
+				.build();
+		}
+
+		return NoticeResponse.builder()
+			.isApply(true)
+			.isRequired(notice.get().isRequired())
+			.message(notice.get().getMessage())
 			.build();
 	}
 }


### PR DESCRIPTION
Resolve #68 

## 구현 기능
동물보호소 컨셉이 적용됨에 따라 기존 사과 유저들에게 보상을 주는
내부 로직을 구현.
추가로 앱 배포에서 서버 중단 이슈가 발생할 수 있어 공지사항 API 추가

## 세부 내용
- [x] 베타 유저 판단 및 보상 로직 구현
- [x] 베타 보상 API 구현
- [x] 공지사항 API 구현